### PR TITLE
Try improve timing of sent metrics

### DIFF
--- a/NewRelic.Platform.Sdk/Runner.cs
+++ b/NewRelic.Platform.Sdk/Runner.cs
@@ -120,7 +120,8 @@ namespace NewRelic.Platform.Sdk
                         return;
                     }
 
-                    Thread.Sleep(pollInterval);
+                    int millisecondsToNextInterval = GetPollInterval() - ((DateTime.Now.Second * 1000) % GetPollInterval()) - DateTime.Now.Millisecond;
+                    Thread.Sleep(millisecondsToNextInterval);
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
New Relic graphs will display as though a metric was missing (0
received) when the timing of metrics in near the end of the minute for a
poll interval of 60000, so instead ensure that metrics are sent near the
beginning of the minute.
